### PR TITLE
Add a named export to react-tether.js

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,8 +3,5 @@
     "es2015",
     "stage-0",
     "react"
-  ],
-  "plugins": [
-    "add-module-exports"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "babel-cli": "^6.16.0",
     "babel-core": "^6.17.0",
     "babel-loader": "^6.2.5",
-    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",

--- a/src/react-tether.js
+++ b/src/react-tether.js
@@ -1,1 +1,2 @@
-export default from './TetherComponent'
+export {default as TetherComponent} from './TetherComponent';
+export default from './TetherComponent';

--- a/src/react-tether.js
+++ b/src/react-tether.js
@@ -1,2 +1,1 @@
-export {default as TetherComponent} from './TetherComponent';
-export default from './TetherComponent';
+export default from './TetherComponent'


### PR DESCRIPTION
Seems like doing this changes the resulting module from TetherComponent to {default: TetherComponent, TetherComponent} which makes importing the module more natural.
Resolves https://github.com/souporserious/react-tether/issues/52