### PR TITLE
Update renovate rules for devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,5 +124,14 @@
   },
   "lint-staged": {
     "*.{js,jsx,json,md}": "pretty-quick --staged"
+  },
+  "renovate": {
+    "devDependencies": {
+      "schedule": ["on the last day of the month"],
+      "automerge": true,
+      "major": {
+        "automerge": false
+      }
+    }
   }
 }


### PR DESCRIPTION
Automerge non-major updates and only run on the last day of the month for devDependencies