### PR TITLE
Add className prop to TetherComponent

### DIFF
--- a/src/react-tether.d.ts
+++ b/src/react-tether.d.ts
@@ -34,5 +34,6 @@ declare namespace ReactTether {
     children: React.ReactNode;
     renderElementTag?: string;
     renderElementTo?: Element | string;
+    className?: string;
   }
 }


### PR DESCRIPTION
which is available on TetherComponent, but not tether options. It can generally serve the same purpose as options.classes on tether.
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26873
@danreeves 