### PR TITLE
Add missing properties to TetherComponentProps type

### DIFF
--- a/src/react-tether.d.ts
+++ b/src/react-tether.d.ts
@@ -35,5 +35,9 @@ declare namespace ReactTether {
     renderElementTag?: string;
     renderElementTo?: Element | string;
     className?: string;
+    id?: string
+    style?: React.CSSProperties
+    onUpdate?: (component: TetherComponent) => void
+    onRepositioned?: (component: TetherComponent) => void
   }
 }


### PR DESCRIPTION
Currently the type does not include `id`, `style`, `onUpdate`, `onRepositioned`, even though those can be passed as props. This change makes it possible to pass these props in TypeScript files.