### PR TITLE
Fix passing of event arguments to on* props

### DIFF
--- a/src/TetherComponent.jsx
+++ b/src/TetherComponent.jsx
@@ -141,14 +141,13 @@ class TetherComponent extends Component {
   }
 
   _registerEventListeners() {
-    this.on('update', () => {
-      return this.props.onUpdate && this.props.onUpdate.apply(this, arguments);
+    this.on('update', (...args) => {
+      return this.props.onUpdate && this.props.onUpdate.apply(this, args);
     });
 
-    this.on('repositioned', () => {
+    this.on('repositioned', (...args) => {
       return (
-        this.props.onRepositioned &&
-        this.props.onRepositioned.apply(this, arguments)
+        this.props.onRepositioned && this.props.onRepositioned.apply(this, args)
       );
     });
   }

--- a/src/react-tether.d.ts
+++ b/src/react-tether.d.ts
@@ -4,7 +4,9 @@ import * as Tether from 'tether';
 export default TetherComponent;
 export as namespace ReactTether;
 
-declare class TetherComponent extends React.Component<ReactTether.TetherComponentProps> {
+declare class TetherComponent extends React.Component<
+  ReactTether.TetherComponentProps
+> {
   props: ReactTether.TetherComponentProps;
 
   static propTypes: ReactTether.TetherComponentProps;
@@ -30,14 +32,22 @@ declare class TetherComponent extends React.Component<ReactTether.TetherComponen
 }
 
 declare namespace ReactTether {
-  interface TetherComponentProps extends React.Props<TetherComponent>, Tether.ITetherOptions {
+  type TetherAttachment = { top: string; left: string };
+  type UpdateEventData = {
+    attachment: TetherAttachment;
+    targetAttachment: TetherAttachment;
+  };
+
+  interface TetherComponentProps
+    extends React.Props<TetherComponent>,
+      Tether.ITetherOptions {
     children: React.ReactNode;
     renderElementTag?: string;
     renderElementTo?: Element | string;
     className?: string;
-    id?: string
-    style?: React.CSSProperties
-    onUpdate?: (component: TetherComponent) => void
-    onRepositioned?: (component: TetherComponent) => void
+    id?: string;
+    style?: React.CSSProperties;
+    onUpdate?: (data: UpdateEventData) => void;
+    onRepositioned?: () => void;
   }
 }

--- a/tests/unit/component.test.js
+++ b/tests/unit/component.test.js
@@ -175,4 +175,44 @@ describe('TetherComponent', () => {
       document.querySelector('#test-container .tether-element')
     ).toBeTruthy();
   });
+
+  it('passes arguments when on onUpdate() is called', () => {
+    const onUpdate = jest.fn();
+    const updateData = {
+      attachment: { top: 'top', left: 'left' },
+      targetAttachment: { top: 'bottom', left: 'right' },
+    };
+    wrapper = mount(
+      <TetherComponent attachment="top left" onUpdate={onUpdate}>
+        <div id="child1" />
+        <div id="child2" />
+      </TetherComponent>
+    );
+    wrapper
+      .instance()
+      .getTetherInstance()
+      .trigger('update', updateData);
+
+    expect(onUpdate).toHaveBeenCalledWith(updateData);
+  });
+
+  it('passes arguments when on onRepositioned() is called', () => {
+    const onRepositioned = jest.fn();
+    const updateData = {
+      foo: 'foo',
+      bar: 'bar',
+    };
+    wrapper = mount(
+      <TetherComponent attachment="top left" onRepositioned={onRepositioned}>
+        <div id="child1" />
+        <div id="child2" />
+      </TetherComponent>
+    );
+    wrapper
+      .instance()
+      .getTetherInstance()
+      .trigger('repositioned', updateData);
+
+    expect(onRepositioned).toHaveBeenCalledWith(updateData);
+  });
 });


### PR DESCRIPTION
The `_registerEventListeners` was using `arguments` in an arrow function. The was referring to `_registerEventListeners` `arguments` (which is always going to be `[]`) because arrow functions do not have their own `arguments`. [From MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions):

> An **arrow function expression** has a shorter syntax than a function expression and does not have its own `this`, `arguments`, `super`, or `new.target`.

I've also updated the typescript typings to reflect the actual event data passed with these events.

