### PR TITLE
add UNSAFE to componentWillUpdate

### DIFF
--- a/src/TetherComponent.jsx
+++ b/src/TetherComponent.jsx
@@ -96,8 +96,8 @@ class TetherComponent extends Component {
     }
   }
 
-  // eslint-disable-next-line react/no-deprecated
-  componentWillUpdate(nextProps) {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillUpdate(nextProps) {
     this.updateChildrenComponents(nextProps);
   }
 


### PR DESCRIPTION
Hello! At work we're trying to update to React 16.10, and we need to make sure all unsafe lifecycle methods have UNSAFE prefixed, so I just wanted to add this so that others who are still dependent on 1.x and can't upgrade yet, have the UNSAFE here.