### PR TITLE
Add targetAttachment to Typescript definitions

### DIFF
--- a/src/react-tether.d.ts
+++ b/src/react-tether.d.ts
@@ -57,6 +57,7 @@ declare namespace ReactTether {
     renderElementTag?: string;
     renderElementTo?: Element | string;
     attachment: string;
+    targetAttachment?: string;
     constraints?: Constraints[];
     className?: string;
     id?: string;


### PR DESCRIPTION
It seems like `react-tether` is missing `targetAttachment` option from [Tether](http://tether.io/).
I've added it to the Typescript definitions.